### PR TITLE
Add context variable to use the line unit price for markup (instead of the product's)

### DIFF
--- a/connector_ecommerce/unit/sale_order_onchange.py
+++ b/connector_ecommerce/unit/sale_order_onchange.py
@@ -165,6 +165,14 @@ class SaleOrderOnChange(OnChangeManager):
             order.get('pricelist_id'),
             line.get('product_id')
         ]
+
+        # used in sale_markup: this is to ensure the unit price
+        # sent by the e-commerce connector is used for markup calculation
+        onchange_context = self.session.context.copy()
+        if line.get('unit_price', False):
+            onchange_context.update({'unit_price': line['unit_price'],
+                                     'force_unit_price': True})
+
         uos_qty = float(line.get('product_uos_qty', 0))
         if not uos_qty:
             uos_qty = float(line.get('product_uom_qty', 0))
@@ -182,7 +190,7 @@ class SaleOrderOnChange(OnChangeManager):
             'packaging': line.get('product_packaging'),
             'fiscal_position': order.get('fiscal_position'),
             'flag': False,
-            'context': self.session.context,
+            'context': onchange_context,
         }
         return args, kwargs
 


### PR DESCRIPTION
Seen with Magento: if a unit price is specified in the imported sale order line, the sale_markup module used to retrieve the OpenERP product's unit price in order to compute the margin & markup rate, and then still will store the Magento unit price in the line.

This PR is related to another PR in OCA/sale-financial, which was done to port the code to Github and add a new facultative variable to the context, 'force_unit_price': https://github.com/OCA/sale-financial/commit/cb1bda088a76b1900e0a4640ad8dffdeb983db62
