### PR TITLE
[FIX] Bug throwing exception importing sale order

### DIFF
--- a/connector_ecommerce/sale.py
+++ b/connector_ecommerce/sale.py
@@ -141,7 +141,7 @@ class SaleOrder(models.Model):
                         order.action_cancel()
                     else:
                         raise ValueError('%s should not fall here.' % state)
-                except (osv.except_osv, osv.orm.except_orm,
+                except (osv.osv.except_osv, osv.orm.except_orm,
                         exceptions.Warning):
                     # the 'cancellation_resolved' flag will stay to False
                     message = _("The sales order could not be automatically "


### PR DESCRIPTION
During a sale order import with the Magento connector extension, while some order has a parent order associated throws the following error:

Traceback (most recent call last):
  File "/opt/odoo/shared/connector/connector/queue/worker.py", line 124, in run_job
    job.perform(session)
  File "/opt/odoo/shared/connector/connector/queue/job.py", line 466, in perform
    self.result = self.func(session, _self.args, *_self.kwargs)
  File "/home/vagrant/connector-magento/magentoerpconnect/unit/import_synchronizer.py", line 379, in import_record
    importer.run(magento_id, force=force)
  File "/home/vagrant/connector-magento/magentoerpconnect/unit/import_synchronizer.py", line 225, in run
    self._after_import(binding)
  File "/home/vagrant/connector-magento/magentoerpconnect/sale.py", line 726, in _after_import
    self._link_parent_orders(binding)
  File "/home/vagrant/connector-magento/magentoerpconnect/sale.py", line 722, in _link_parent_orders
    parent_binding.write({'canceled_in_backend': True})
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/opt/odoo/shared/connector/connector/producer.py", line 62, in write
    result = write_original(self, vals)
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/opt/odoo/shared/odoo-server/openerp/models.py", line 3778, in write
    self._write(old_vals)
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 547, in new_api
    result = method(self._model, cr, uid, self.ids, _args, *_kwargs)
  File "/opt/odoo/shared/odoo-server/openerp/models.py", line 3941, in _write
    self.pool[table].write(cr, user, nids, v, context)
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 241, in wrapper
    return old_api(self, _args, *_kwargs)
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 363, in old_api
    result = method(recs, _args, *_kwargs)
  File "/home/vagrant/connector-magento/magentoerpconnect/sale.py", line 151, in write
    return super(SaleOrder, self).write(vals)
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/home/vagrant/connector-ecommerce/connector_ecommerce/sale.py", line 186, in write
    self._try_auto_cancel()
  File "/opt/odoo/shared/odoo-server/openerp/api.py", line 239, in wrapper
    return new_api(self, _args, *_kwargs)
  File "/home/vagrant/connector-ecommerce/connector_ecommerce/sale.py", line 144, in _try_auto_cancel
    except (osv.except_osv, osv.orm.except_orm,
AttributeError: 'module' object has no attribute 'except_osv'
