### PR TITLE
[FIX] set cancellation resolved when sale order has been manually canceled

### DIFF
--- a/connector_ecommerce/sale.py
+++ b/connector_ecommerce/sale.py
@@ -162,9 +162,16 @@ class sale_order(orm.Model):
                            "<li>Cancel the sales order manually.</li>"
                            "</ol></p>")
         for order_id in ids:
-            state = self.read(cr, uid, order_id,
-                              ['state'], context=context)['state']
+            order = self.read(cr, uid, order_id,
+                              ['state', 'cancellation_resolved'],
+                              context=context)
+            state = order['state']
             if state == 'cancel':
+                if not order['cancellation_resolved']:
+                    # the sale order has been manually cancelled in the erp.
+                    self.write(
+                        cr, uid, order_id, {'cancellation_resolved': True},
+                        context=context)
                 continue
             elif state == 'done':
                 message = _("The sales order cannot be automatically "


### PR DESCRIPTION
Hello, 

This PR fix an issue you can face if you cancel manually a sale order in Odoo. 

Steps to face the problem : 
- import a sale order from a backend (ex: magento)
- cancel it in Odoo
- modify it in Magento (so the sale order is cancelled in Magento and a child order is created)
- import the child sale order in Odoo
- try to confirm the child sale order, you get an exception error : need to cancel parent in backend.

When you import the child sale order in Odoo, the parent is cancelled so the module tries to cancel the parent in Odoo.
In the 'normal' case (the sale order is not cancelled in Odoo yet), the module use the method action_cancel to cancel the sale order and set the field cancellation_resolved to True.
In the present case, the sale order is already cancelled so it does nothing, so the field cancellation_resolved is still False. The result is that the child sale order cannot be confirmed.

I make also a PR for v8.

Thanks for your reviews.
