### PR TITLE
[FIX] set cancellation_resolved to true when sale order has been manually canceled

### DIFF
--- a/connector_ecommerce/sale.py
+++ b/connector_ecommerce/sale.py
@@ -126,6 +126,9 @@ class SaleOrder(models.Model):
         for order in self:
             state = order.state
             if state == 'cancel':
+                # the sale order has been manually cancelled.
+                if not order.cancellation_resolved:
+                    order.cancellation_resolved = True
                 continue
             elif state == 'done':
                 message = _("The sales order cannot be automatically "


### PR DESCRIPTION
Hi, 

This PR is the port of a PR in v7 to fix a bug. https://github.com/OCA/connector-ecommerce/pull/24

I repeat the explanation here : 

Steps to face the problem :

import a sale order from a backend (ex: magento)
cancel it in Odoo
modify it in Magento (so the sale order is cancelled in Magento and a child order is created)
import the child sale order in Odoo
try to confirm the child sale order, you get an exception error : need to cancel parent in backend.
When you import the child sale order in Odoo, the parent is cancelled so the module tries to cancel the parent in Odoo.
In the 'normal' case (the sale order is not cancelled in Odoo yet), the module use the method action_cancel to cancel the sale order and set the field cancellation_resolved to True.
In the present case, the sale order is already cancelled so it does nothing, so the field cancellation_resolved is still False. The result is that the child sale order cannot be confirmed.

Thanks for your reviews.
