### PR TITLE
Fire new event: 'on_picking_dropship_done' 

### DIFF
--- a/connector_ecommerce/models/stock.py
+++ b/connector_ecommerce/models/stock.py
@@ -33,20 +33,16 @@ class StockPicking(models.Model):
         self_context = self.with_context(__no_on_event_out_done=True)
         result = super(StockPicking, self_context).do_transfer()
         for picking in self:
-            if picking.related_backorder_ids:
-                method = 'partial'
-            else:
-                method = 'complete'
+            method = 'partial' if picking.related_backorder_ids else 'complete'
             if picking.picking_type_id.code == 'outgoing':
                 self._event('on_picking_out_done').notify(picking, method)
                 # deprecated:
                 on_picking_out_done.fire(self.env, 'stock.picking',
                                          picking.id, method)
-            elif picking.picking_type_id.code == 'incoming' \
-                    and picking.location_dest_id.usage == 'customer':
+            elif (picking.picking_type_id.code == 'incoming'
+                  and picking.location_dest_id.usage == 'customer'):
                 self._event('on_picking_dropship_done').notify(picking, method)
-
-
+        
         return result
 
 

--- a/connector_ecommerce/models/stock.py
+++ b/connector_ecommerce/models/stock.py
@@ -33,21 +33,17 @@ class StockPicking(models.Model):
         self_context = self.with_context(__no_on_event_out_done=True)
         result = super(StockPicking, self_context).do_transfer()
         for picking in self:
+            if picking.related_backorder_ids:
+                method = 'partial'
+            else:
+                method = 'complete'
             if picking.picking_type_id.code == 'outgoing':
-                if picking.related_backorder_ids:
-                    method = 'partial'
-                else:
-                    method = 'complete'
                 self._event('on_picking_out_done').notify(picking, method)
                 # deprecated:
                 on_picking_out_done.fire(self.env, 'stock.picking',
                                          picking.id, method)
             elif picking.picking_type_id.code == 'incoming' \
                     and picking.location_dest_id.usage == 'customer':
-                if picking.related_backorder_ids:
-                    method = 'partial'
-                else:
-                    method = 'complete'
                 self._event('on_picking_dropship_done').notify(picking, method)
 
 


### PR DESCRIPTION
When an 'incoming' shipment happens but is effectively a 'dropship', fire a new event named 'on_picking_dropship_done'.

This currently implements a new event. This could be implemented as just 'detection' and emitting the current event ('on_picking_out_done').  (My current test is functionally the `connector_magento` add-on with my _implementation_ basically just re-calling the current event handler.)

https://github.com/OCA/connector-magento/issues/265