### PR TITLE
[FIX] 10.0 on_product_price_changed event with new API

### DIFF
--- a/connector_ecommerce/models/product.py
+++ b/connector_ecommerce/models/product.py
@@ -51,7 +51,7 @@ class ProductTemplate(models.Model):
                 remove_products = product_model.browse(from_product_ids)
                 products -= remove_products
             for product in products:
-                self._event('on_product_price_changed').notify(product)
+                product._event('on_product_price_changed').notify(product)
                 # deprecated:
                 on_product_price_changed.fire(self.env,
                                               product_model._name,

--- a/connector_ecommerce/tests/__init__.py
+++ b/connector_ecommerce/tests/__init__.py
@@ -3,3 +3,4 @@
 from . import test_onchange
 from . import test_invoice_event
 from . import test_picking_event
+from . import test_product_event

--- a/connector_ecommerce/tests/test_product_event.py
+++ b/connector_ecommerce/tests/test_product_event.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# © 2018 Akretion
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html)
+
+import mock
+
+import odoo.tests.common as common
+
+
+class TestProductEvent(common.TransactionCase):
+    """ Test if the events on the products are fired correctly """
+
+    def setUp(self):
+        super(TestProductEvent, self).setUp()
+        self.product_product = self.env.ref('product.product_product_6')
+        self.product_template = self.env.ref(
+                'product.product_product_11_product_template')
+
+    def test_event_on_product_product_price_changed(self):
+        """ Test if the ``on_product_price_changed`` event is fired
+        when a product product price is changed"""
+        event = ('odoo.addons.connector_ecommerce.models.'
+                 'product.on_product_price_changed')
+        with mock.patch(event) as event_mock:
+            self.product_product.update({'lst_price': 1000.0})
+            self.assertEquals(self.product_product.lst_price, 1000.0)
+            event_mock.fire.assert_called_with(mock.ANY,
+                                               'product.product',
+                                               self.product_product.id)
+
+    def test_event_on_product_template_price_changed(self):
+        """ Test if the ``on_product_price_changed`` event is fired
+        when a product template price is changed"""
+        event = ('odoo.addons.connector_ecommerce.models.'
+                 'product.on_product_price_changed')
+        with mock.patch(event) as event_mock:
+            self.product_template.update({'list_price': 1000.0})
+            self.assertEquals(self.product_template.list_price, 1000.0)
+            self.assertEquals(event_mock.fire.call_count, 2)
+            event_mock.fire.assert_called_with(mock.ANY,
+                                               'product.product',
+                                               mock.ANY)

--- a/connector_ecommerce/tests/test_product_event.py
+++ b/connector_ecommerce/tests/test_product_event.py
@@ -14,7 +14,7 @@ class TestProductEvent(common.TransactionCase):
         super(TestProductEvent, self).setUp()
         self.product_product = self.env.ref('product.product_product_6')
         self.product_template = self.env.ref(
-                'product.product_product_11_product_template')
+            'product.product_product_11_product_template')
 
     def test_event_on_product_product_price_changed(self):
         """ Test if the ``on_product_price_changed`` event is fired


### PR DESCRIPTION
While migrating the connector_magento_pricing module I had trouble getting notifications from the "on_product_price_changed" event.

I wrote tests for the event to make sure this wasn't the cause. While doing so I realized the old API fired the event as expected but the new one did not. In fact when the change is done on a product.template, the product.products are notified with the old API but the notification is done on the product.template with the new API.

I made a fix that corrected my problem and everything works now. I am not sure this is the right way to do it (the use of 'product' is redundant).
Also, I have no idea how to test with the new API so my test does not cover this case but only the old way.