### PR TITLE
[11.0] [FIX] _compute_tax_group_id: Filter taxes by company

### DIFF
--- a/connector_ecommerce/models/product.py
+++ b/connector_ecommerce/models/product.py
@@ -13,8 +13,11 @@ class ProductTemplate(models.Model):
     @api.one
     @api.depends('taxes_id.tax_group_id')
     def _compute_tax_group_id(self):
-        taxes = self.taxes_id
+        company = self.env.user.company_id
+        taxes = self.taxes_id.filtered(
+            lambda r: r.company_id.id == company.id)
         self.tax_group_id = taxes[:-1].tax_group_id.id
+
     tax_group_id = fields.Many2one(
         comodel_name='account.tax.group',
         compute='_compute_tax_group_id',


### PR DESCRIPTION
Filter product taxes by the selected company in user to avoid singleton
error if product has taxes for more than one company and the method is
called with admin user