### PR TITLE
Fix :  Don't parse onchange resullt when returning  False instead of nothing

### DIFF
--- a/connector_ecommerce/components/sale_order_onchange.py
+++ b/connector_ecommerce/components/sale_order_onchange.py
@@ -18,8 +18,8 @@ class OnChangeManager(Component):
             if fieldname not in record:
                 if model:
                     column = self.env[model]._fields[fieldname]
-                    if column.type == 'many2one':
-                        value = value[0]  # many2one are tuple (id, name)
+                    if column.type == 'many2one' and value is not False:
+                        value = value[0]   # many2one are tuple (id, name)
                 new_values[fieldname] = value
         return new_values
 

--- a/connector_ecommerce/data/ecommerce_data.xml
+++ b/connector_ecommerce/data/ecommerce_data.xml
@@ -51,11 +51,9 @@
                 is canceled.</field>
             <field name="sequence">30</field>
             <field name="model">sale.order</field>
-            <field name="rule_group">sale</field>
             <field name="code">if sale.parent_need_cancel:
                 failed = True</field>
             <field name="active" eval="True" />
-            <field name="rule_group">sale</field>
         </record>
 
         <record id="excep_order_need_cancel" model="exception.rule">
@@ -64,10 +62,8 @@
                 backend.</field>
             <field name="sequence">20</field>
             <field name="model">sale.order</field>
-            <field name="rule_group">sale</field>
             <field name="code">if sale.need_cancel: failed = True</field>
             <field name="active" eval="True" />
-            <field name="rule_group">sale</field>
         </record>
 
         <record id="excep_product_has_checkpoint" model="exception.rule">
@@ -77,10 +73,8 @@
                 Go to Connectors > Checkpoint and review the new products.</field>
             <field name="sequence">20</field>
             <field name="model">sale.order.line</field>
-            <field name="rule_group">sale</field>
             <field name="code">if object.product_id and object.product_id.has_checkpoint: failed = True</field>
             <field name="active" eval="True" />
-            <field name="rule_group">sale</field>
         </record>
 
     </data>


### PR DESCRIPTION
In case of onchange method calling method that retrun possible false values https://github.com/OCA/OCB/blob/10.0/addons/account/models/partner.py#L162 the syntax value[0] failed because of the structure fo the dictionnary : 
values = {'fiscal_position_id': False}
This patch prevent to pass in those lines