### PR TITLE
[FIX] connector_ecommerce: fix exception on set False M2o fields.

### DIFF
--- a/connector_ecommerce/components/sale_order_onchange.py
+++ b/connector_ecommerce/components/sale_order_onchange.py
@@ -18,7 +18,7 @@ class OnChangeManager(Component):
             if fieldname not in record:
                 if model:
                     column = self.env[model]._fields[fieldname]
-                    if column.type == 'many2one':
+                    if column.type == 'many2one' and value:
                         value = value[0]  # many2one are tuple (id, name)
                 new_values[fieldname] = value
         return new_values


### PR DESCRIPTION
Exception corrected "TypeError: 'bool' object is not subscriptable"

Mapper returns something like `{'fiscal_position_id': False}`, perfectly valid values, but read will not read/return something like (False, 'Undefined') but just False.