### PR TITLE
[FIX] connector_ecommerce: Return account.move post() results

### DIFF
--- a/connector_ecommerce/models/invoice.py
+++ b/connector_ecommerce/models/invoice.py
@@ -8,8 +8,9 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     def post(self):
-        super().post()
+        res = super().post()
         self.notify_invoice_validate()
+        return res
 
     def action_invoice_paid(self):
         res = super().action_invoice_paid()


### PR DESCRIPTION
Without return of results e.g. actions won't be returned