### PR TITLE
[FIX] connector_ecommerce: remove obsoleted rule

### DIFF
--- a/connector_ecommerce/__manifest__.py
+++ b/connector_ecommerce/__manifest__.py
@@ -4,7 +4,7 @@
 
 {
     "name": "Connector for E-Commerce",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Hidden",
     "author": "Camptocamp,Akretion,Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/connector-ecommerce",

--- a/connector_ecommerce/migrations/14.0.1.0.1/post-migration.py
+++ b/connector_ecommerce/migrations/14.0.1.0.1/post-migration.py
@@ -1,0 +1,7 @@
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate(use_env=True)
+def migrate(env, version):
+    old_rules = ["connector_ecommerce.excep_product_has_checkpoint"]
+    openupgrade.delete_records_safely_by_xml_id(old_rules)


### PR DESCRIPTION
The column `has_checkpoint` has been removed by commit https://github.com/OCA/connector-ecommerce/commit/f9e320d115ffb2e4bd2f4e6f7771cf3ad21518d6. This is to unlink obsoleted rule `A product needs to be reviewed.`