### PR TITLE
Fix sale order onchange failure on False value on M2o

### DIFF
--- a/connector_ecommerce/components/sale_order_onchange.py
+++ b/connector_ecommerce/components/sale_order_onchange.py
@@ -18,7 +18,16 @@ class OnChangeManager(Component):
                 if model:
                     column = self.env[model]._fields[fieldname]
                     if column.type == "many2one":
-                        value = value[0]  # many2one are tuple (id, name)
+                        if value:
+                            assert (
+                                isinstance(value, (tuple, list)) and len(value) == 2
+                            ), (
+                                "onchange() on model %s "
+                                "should return a tuple with 2 elements "
+                                "(id, name) as value for many2one field %s"
+                                % (model, fieldname)
+                            )
+                            value = value[0]
                 new_values[fieldname] = value
         return new_values
 


### PR DESCRIPTION
When an onchange returns False for a m2o field, the sale order onchange component will fail because it tries to get the first item of the tuple (id, name). We should just keep the False value.